### PR TITLE
Add in class-related style guides

### DIFF
--- a/ruby_style_guide.rb
+++ b/ruby_style_guide.rb
@@ -284,14 +284,18 @@
   # file class_name.rb
   class ClassName
     include SomeMethods
-
-    def other_method; end
   end
   # end file
 
   # file some_methods.rb
   module SomeMethods
     def some_method; end #implies trivial methods with no complexities justifying breaking out for testing purposes
+  end
+  # end file
+
+  # file other_methods.rb
+  class ClassName
+    def other_method; end #this is bad since it should just go in class_name.rb
   end
   # end file
 


### PR DESCRIPTION
- You may but do not have to use class << self; def method in lieu of def self.method for groups of >= 5 class methods
- Always omit explicit object references when implicit ones suffice, excepting inheritance needs
- Do not split classes/modules across multiple files, split them across multiple modules/classes in their own files. Do not split into multiple modules for the sole purpose of splitting into multiple files, it should be to aid testing or to share code.
